### PR TITLE
Reserve and cancel button

### DIFF
--- a/src/components/rockets/rockets.css
+++ b/src/components/rockets/rockets.css
@@ -19,6 +19,16 @@
   font-weight: bold;
 }
 
+.reserved {
+  color: #fff;
+  font-size: 12px;
+  padding: 3px;
+  background-color: #0b84f5;
+  border: none;
+  border-radius: 5px;
+  margin-right: 10px;
+}
+
 .reservation-button {
   width: 110px;
   height: 35px;
@@ -28,6 +38,16 @@
   border-radius: 5px;
 }
 
-.reservation-button:hover {
+.cancel-reservation-button {
+  width: 130px;
+  height: 35px;
+  color: gray;
+  background-color: none;
+  border: 1px solid gray;
+  border-radius: 5px;
+}
+
+.reservation-button:hover,
+.cancel-reservation-button:hover {
   cursor: pointer;
 }

--- a/src/components/rockets/rockets.css
+++ b/src/components/rockets/rockets.css
@@ -42,7 +42,7 @@
   width: 130px;
   height: 35px;
   color: gray;
-  background-color: none;
+  background-color: white;
   border: 1px solid gray;
   border-radius: 5px;
 }

--- a/src/components/rockets/rockets.js
+++ b/src/components/rockets/rockets.js
@@ -1,7 +1,7 @@
 import './rockets.css';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { fetchRocketsData } from '../../redux/rockets/rocketsSlice';
+import { fetchRocketsData, reserveRocket, cancelReserve } from '../../redux/rockets/rocketsSlice';
 
 const Rockets = () => {
   const rocketsData = useSelector((state) => state.rockets);
@@ -19,8 +19,18 @@ const Rockets = () => {
           <img src={rocket.flickr_images} className="rocket-image" alt={rocket.id} />
           <div className="rocket-data">
             <p className="rocket-title">{rocket.rocket_name}</p>
-            <p className="rocket-description">{rocket.description}</p>
-            <button type="button" className="reservation-button">Reserve Rocket</button>
+            <p className="rocket-description">
+              {rocket.reserved === true ? <span className="reserved">Reserved</span> : ''}
+              {rocket.description}
+            </p>
+            { rocket.reserved === false
+              ? (
+                <button onClick={() => { dispatch(reserveRocket(rocket.id)); }} type="button" className="reservation-button">Reserve Rocket</button>
+              )
+              : (
+                <button onClick={() => { dispatch(cancelReserve(rocket.id)); }} type="button" className="cancel-reservation-button">Cancel Reservation</button>
+              )
+            }
           </div>
         </div>
       ))}

--- a/src/components/rockets/rockets.js
+++ b/src/components/rockets/rockets.js
@@ -29,8 +29,7 @@ const Rockets = () => {
               )
               : (
                 <button onClick={() => { dispatch(cancelReserve(rocket.id)); }} type="button" className="cancel-reservation-button">Cancel Reservation</button>
-              )
-            }
+              )}
           </div>
         </div>
       ))}

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -4,7 +4,6 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 const rocketsAPI = 'https://api.spacexdata.com/v3/rockets';
 
 // fetching data from API
-
 export const fetchRocketsData = createAsyncThunk('fetchRocketsData', async () => {
   const response = await fetch(rocketsAPI);
   const data = await response.json();
@@ -15,6 +14,7 @@ export const fetchRocketsData = createAsyncThunk('fetchRocketsData', async () =>
       rocket_name: item.rocket_name,
       description: item.description,
       flickr_images: item.flickr_images[0],
+      reserved: false,
     });
   });
   return allRockets;
@@ -23,10 +23,29 @@ export const fetchRocketsData = createAsyncThunk('fetchRocketsData', async () =>
 const rocketsSlice = createSlice({
   name: 'rockets',
   initialState: [],
+  reducers: {
+    reserveRocket(state, action) {
+      return state.map((rocket) => {
+        if (rocket.id !== action.payload) {
+          return { ...rocket };
+        }
+        return { ...rocket, reserved: true };
+      });
+    },
+    cancelReserve(state, action) {
+      return state.map((rocket) => {
+        if (rocket.id !== action.payload) {
+          return { ...rocket };
+        }
+        return { ...rocket, reserved: false };
+      });
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchRocketsData.fulfilled, (state, action) => action.payload);
   },
 });
 
+export const { reserveRocket, cancelReserve } = rocketsSlice.actions;
 export default rocketsSlice.reducer;


### PR DESCRIPTION
**I have done the following:**

- When a user clicks the "Reserve Rocket" button, the action dispatches to update the store. It gets the ID of the reserved rocket and updates the state. It returns a new state object with all rockets.
- When a user clicks the "Cancel Reservation" button it sets the `reserved` key to `false` and returns the state.
- Rockets that have already been reserved display a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve Rocket".